### PR TITLE
Add config files.

### DIFF
--- a/.plateform.app.yaml
+++ b/.plateform.app.yaml
@@ -1,0 +1,31 @@
+# The name of this app. Must be unique within a project.
+name: app
+
+# The runtime the application uses. The 'type' key defines the base container
+# image that will be used to run the application. There is a separate base
+# container image for each primary language for the application,
+# in multiple versions. Check the PHP documentation
+# (https://docs.platform.sh/languages/php.html#supported-versions)
+# to find the supported versions for the 'php' type.
+type: 'php:8.4'
+
+# The following block defines a single writable directory, 'web/uploads'
+# The 'source' specifies where the writable mount is. The 'local' source
+# indicates that the mount point will point to a local directory on the
+# application container. The 'source_path' specifies the subdirectory
+# from within the source that the mount should point at. 
+mounts:
+  'web/uploads':
+    source: local
+    source_path: uploads
+
+# The size of the persistent disk of the application (in MB).
+disk: 256
+
+# The relationships of the application with services or other applications.
+#
+# The left-hand side is the name of the relationship as it will be exposed
+# to the application in the PLATFORM_RELATIONSHIPS variable. The right-hand
+# side is in the form '<service name>:<endpoint name>'.
+relationships:
+    mysql: 'mysql:mysql'

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,0 +1,8 @@
+# Each route describes how an incoming URL is going to be processed by Platform.sh.
+"https://www.{default}/":
+    type: upstream
+    upstream: "app:http"
+
+"https://{default}/":
+    type: redirect
+    to: "https://www.{default}/"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,0 +1,10 @@
+# The name given to the MariaDB/MySQL service (lowercase alphanumeric only).
+# mysql:
+    # The type of your service (mysql), which uses the format
+    # 'type:version'. Be sure to consult the MariaDB/MySQL documentation
+    # (https://docs.platform.sh/add-services/mysql.html#supported-versions)
+    # when choosing a version. If you specify a version number which is not available,
+    # the CLI will return an error.
+    # type: mysql:11.0
+    # The disk attribute is the size of the persistent disk (in MB) allocated to the service.
+    # disk: 256


### PR DESCRIPTION
This pull request includes configuration changes to set up the application environment on Platform.sh. The changes involve defining the application's runtime, routes, and services.

Configuration updates:

* [`.platform.app.yaml`](diffhunk://#diff-8784345732d5d52b252462790ea5c4de4c382cb7a95d751e6786675c57b524eaR1-R31): Added configuration to define the application name, runtime type as `php:8.4`, writable directory mounts, disk size, and relationships with services, specifically a MySQL service.
* [`.platform/routes.yaml`](diffhunk://#diff-3d5ac9c9731328da5bd3dd1524d525a1b93d68aa77c9a6961776934d4498ed04R1-R8): Added route configurations to handle incoming URLs, including an upstream route for `https://www.{default}/` and a redirect route for `https://{default}/` to `https://www.{default}/`.
* [`.platform/services.yaml`](diffhunk://#diff-51b4e431e580be333e0a587d68241890e7a3bf2ccc8c0bf840753ca08dacde9fR1-R10): Added a template for defining a MariaDB/MySQL service, including the service type and version, and disk size.